### PR TITLE
Added reference of Kroki Extension to readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Custom parsers/renderers can be bundled into extensions which extend CommonMark.
  - [Sup Sub extensions](https://github.com/OWS/commonmark-sup-sub-extensions) - Adds support of superscript and subscript (`<sup>` and `<sub>` HTML tags)
  - [YouTube iframe extension](https://github.com/zoonru/commonmark-ext-youtube-iframe) - Replaces youtube link with iframe.
  - [Lazy Image extension](https://github.com/simonvomeyser/commonmark-ext-lazy-image) - Adds various options for lazy loading of images.
+ - [Kroki diagrams extension](https://github.com/ramnzys/commonmark-kroki) - Adds support for rendering diagrams from textual descriptions.
 
 Others can be found on [Packagist under the `commonmark-extension` package type](https://packagist.org/packages/league/commonmark?type=commonmark-extension).
 


### PR DESCRIPTION
I've have created an extension that adds support for rendering diagram from textual descriptions. Supports graphviz, plantuml, mermaid, etc. Can be used with public free server or self hosted.
